### PR TITLE
Fix property names and typecasting

### DIFF
--- a/src/Events/BmcEvent.php
+++ b/src/Events/BmcEvent.php
@@ -23,7 +23,7 @@ abstract class BmcEvent
             $request->boolean('live_mode'),
             $request->integer('attempt'),
             $request->date('created'),
-            $request->integer('eventId'),
+            $request->integer('event_id'),
         );
     }
 

--- a/src/Events/BmcEvent.php
+++ b/src/Events/BmcEvent.php
@@ -99,6 +99,6 @@ abstract class BmcEvent
 
     public function supporterEmail(): string
     {
-        return (string) data_get($this->payload, 'supporter_name');
+        return (string) data_get($this->payload, 'supporter_email');
     }
 }

--- a/src/Events/BmcEvent.php
+++ b/src/Events/BmcEvent.php
@@ -8,7 +8,7 @@ use Rokde\LaravelBuyMeACoffeeWebhookHandler\Transformer\Boolean;
 
 abstract class BmcEvent
 {
-    public function __construct(
+    final public function __construct(
         protected array $payload,
         private bool $liveMode,
         private int $attempt,

--- a/src/Events/MembershipEvent.php
+++ b/src/Events/MembershipEvent.php
@@ -34,7 +34,7 @@ abstract class MembershipEvent extends BmcEvent
 
     public function membershipLevelName(): string
     {
-        return (int) data_get($this->payload, 'membership_level_name');
+        return (string) data_get($this->payload, 'membership_level_name');
     }
 
     public function startedAt(): Carbon


### PR DESCRIPTION
This PR fixes 3 minor issues related to property names and typecasting in the BmcEvent classes:

* use the correct `event_id` parameter name in the `BmcEvent` constructor
* use the correct `supporter_email` parameter name in the BmcEvent::supporterEmail() method
* use the correct string typecast in the MembershipEvent::membershipLevelName() method

In addition, it marks the constructor of the BmcEvent final which suppresses a phpstan warning.